### PR TITLE
Add a simple User vertical slice

### DIFF
--- a/agent/src/main/java/com/example/agent/domain/User.java
+++ b/agent/src/main/java/com/example/agent/domain/User.java
@@ -1,0 +1,3 @@
+package com.example.agent.domain;
+
+public record User(Long id, String name) {}

--- a/agent/src/main/java/com/example/agent/service/UserService.java
+++ b/agent/src/main/java/com/example/agent/service/UserService.java
@@ -1,0 +1,24 @@
+package com.example.agent.service;
+
+import com.example.agent.domain.User;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class UserService {
+
+    private static final List<User> USERS = List.of(
+            new User(1L, "Alice"),
+            new User(2L, "Bob")
+    );
+
+    public List<User> findAll() {
+        return USERS;
+    }
+
+    public Optional<User> findById(Long id) {
+        return USERS.stream().filter(u -> u.id().equals(id)).findFirst();
+    }
+}

--- a/agent/src/main/java/com/example/agent/web/UserController.java
+++ b/agent/src/main/java/com/example/agent/web/UserController.java
@@ -1,0 +1,34 @@
+package com.example.agent.web;
+
+import com.example.agent.domain.User;
+import com.example.agent.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/users")
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping
+    public List<User> listUsers() {
+        return userService.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<User> getUser(@PathVariable Long id) {
+        return userService.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+}

--- a/agent/src/test/java/com/example/agent/service/UserServiceTest.java
+++ b/agent/src/test/java/com/example/agent/service/UserServiceTest.java
@@ -1,0 +1,37 @@
+package com.example.agent.service;
+
+import com.example.agent.domain.User;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserServiceTest {
+
+    private final UserService userService = new UserService();
+
+    @Test
+    void findAll_returnsAllUsers() {
+        List<User> users = userService.findAll();
+
+        assertThat(users).hasSize(2);
+        assertThat(users).extracting(User::name).containsExactly("Alice", "Bob");
+    }
+
+    @Test
+    void findById_withExistingId_returnsUser() {
+        Optional<User> user = userService.findById(1L);
+
+        assertThat(user).isPresent();
+        assertThat(user.get().name()).isEqualTo("Alice");
+    }
+
+    @Test
+    void findById_withUnknownId_returnsEmpty() {
+        Optional<User> user = userService.findById(99L);
+
+        assertThat(user).isEmpty();
+    }
+}

--- a/agent/src/test/java/com/example/agent/web/UserControllerTest.java
+++ b/agent/src/test/java/com/example/agent/web/UserControllerTest.java
@@ -1,0 +1,56 @@
+package com.example.agent.web;
+
+import com.example.agent.domain.User;
+import com.example.agent.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserService userService;
+
+    @Test
+    void listUsers_returnsJsonArray() throws Exception {
+        when(userService.findAll()).thenReturn(List.of(new User(1L, "Alice"), new User(2L, "Bob")));
+
+        mockMvc.perform(get("/users"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].name").value("Alice"))
+                .andExpect(jsonPath("$[1].name").value("Bob"));
+    }
+
+    @Test
+    void getUser_withExistingId_returnsUser() throws Exception {
+        when(userService.findById(1L)).thenReturn(Optional.of(new User(1L, "Alice")));
+
+        mockMvc.perform(get("/users/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.name").value("Alice"));
+    }
+
+    @Test
+    void getUser_withUnknownId_returns404() throws Exception {
+        when(userService.findById(99L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/users/99"))
+                .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `User` domain record (`id`, `name`)
- Add `UserService` with in-memory `findAll()` / `findById()`
- Add `UserController` exposing `GET /users` and `GET /users/{id}` (404 on miss)
- Add unit tests for service and MockMvc tests for controller

Closes #5

## Test plan
- [ ] `./gradlew test` passes
- [ ] `GET /users` returns empty list on fresh start
- [ ] `GET /users/{id}` returns 404 for unknown id

🤖 Generated with [Claude Code](https://claude.com/claude-code)